### PR TITLE
Add sorting buttons and move functionality

### DIFF
--- a/controller.go
+++ b/controller.go
@@ -25,3 +25,9 @@ func (c *Controller) ShowPrevImage() {
 		c.V.ShowImage()
 	}
 }
+
+func (c *Controller) MoveImage(folder string) {
+	if c.M.MoveCurrentImage(folder) {
+		c.V.ShowImage()
+	}
+}

--- a/model.go
+++ b/model.go
@@ -77,3 +77,30 @@ func (m *Model) Prev() (_ bool) {
 	}
 	return
 }
+
+func (m *Model) MoveCurrentImage(folder string) (_ bool) {
+	if len(m.images) == 0 {
+		return
+	}
+
+	current := string(m.CurrentImage())
+	base := fp.Base(current)
+
+	if err := os.MkdirAll(folder, 0o755); err != nil {
+		log.Printf("Error creating folder %s: %v\n", folder, err)
+		return
+	}
+
+	dest := fp.Join(folder, base)
+	if err := os.Rename(current, dest); err != nil {
+		log.Printf("Error moving file: %v\n", err)
+		return
+	}
+
+	m.images = append(m.images[:m.index], m.images[m.index+1:]...)
+	if m.index >= len(m.images) && m.index > 0 {
+		m.index--
+	}
+
+	return true
+}

--- a/view.go
+++ b/view.go
@@ -30,10 +30,17 @@ func (v *View) Init(a fy.App) {
 		v.label,
 		v.label2,
 	)
-	buttons := fct.NewHBox(
+	navButtons := fct.NewHBox(
 		fwg.NewButton(`Prev`, v.c.ShowPrevImage),
 		fwg.NewButton(`Next`, v.c.ShowNextImage),
 	)
+	sortButtons := fct.NewHBox(
+		fwg.NewButton(`Glass`, func() { v.c.MoveImage("glass") }),
+		fwg.NewButton(`Metal`, func() { v.c.MoveImage("metal") }),
+		fwg.NewButton(`Paper`, func() { v.c.MoveImage("paper") }),
+		fwg.NewButton(`Plastic`, func() { v.c.MoveImage("plastic") }),
+	)
+	buttons := fct.NewVBox(navButtons, sortButtons)
 	content := fct.NewBorder(labels, buttons, nil, nil, v.img)
 
 	v.window = a.NewWindow(string(v.c.M.ImagesDir))


### PR DESCRIPTION
## Summary
- add buttons to sort images into `glass`, `metal`, `paper`, and `plastic`
- implement moving of image files and folder creation

## Testing
- `go vet ./...` *(fails: Get https://storage.googleapis.com/... : Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_684343ae6e6083319b1cf7a4d491f0bf